### PR TITLE
Fix is_receipt parameter name

### DIFF
--- a/app/models/parsed_transaction_message.py
+++ b/app/models/parsed_transaction_message.py
@@ -67,8 +67,8 @@ class ParsedTransactionMessage:
     def local_amount(self) -> float:
         return round(self.get_amount() * self.exchange_rate(), 2)
 
-    def getDate(self, is_recept: bool = False):
-        if is_recept:
+    def getDate(self, is_receipt: bool = False):
+        if is_receipt:
             self.is_receipt = True
 
         # use %M for minutes, %S for seconds


### PR DESCRIPTION
## Summary
- rename `is_recept` parameter to `is_receipt` in `getDate`

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_683fe73cad988331ab55ecf226fdf994